### PR TITLE
dockerfiles: various

### DIFF
--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -49,6 +49,7 @@ RUN yum -y install epel-release && \
         xz \
         screen \
         tmux \
+        sudo \
         which && \
     yum -y clean all && \
     groupadd -g 1000 yoctouser && \

--- a/dockerfiles/debian/debian-8/debian-8-base/Dockerfile
+++ b/dockerfiles/debian/debian-8/debian-8-base/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get clean && \
         locales \
         screen \
         tmux \
+        sudo \
         tightvncserver && \
     apt-get clean && \
     useradd -U -m yoctouser && \

--- a/dockerfiles/fedora/fedora-22/fedora-22-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-22/fedora-22-base/Dockerfile
@@ -50,6 +50,7 @@ RUN dnf -y install \
         file \
         screen \
         tmux \
+        sudo \
         tigervnc-server && \
     dnf -y clean all && \
     useradd -U -m yoctouser && \

--- a/dockerfiles/fedora/fedora-23/fedora-23-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-23/fedora-23-base/Dockerfile
@@ -52,6 +52,7 @@ RUN dnf -y update && \
         xz \
         screen \
         tmux \
+        sudo \
         tigervnc-server && \
     dnf -y clean all && \
     useradd -U -m yoctouser && \

--- a/dockerfiles/fedora/fedora-24/fedora-24-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-24/fedora-24-base/Dockerfile
@@ -52,6 +52,7 @@ RUN dnf -y update && \
         xz \
         screen \
         tmux \
+        sudo \
         tigervnc-server && \
     dnf -y clean all && \
     useradd -U -m yoctouser && \

--- a/dockerfiles/opensuse/opensuse-13.2/opensuse-13.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-13.2/opensuse-13.2-base/Dockerfile
@@ -36,6 +36,7 @@ RUN zypper --non-interactive install python \
                    python3-curses \
                    screen \
                    tmux \
+                   sudo \
                    libSDL-devel && \
     useradd -U -m yoctouser
 

--- a/dockerfiles/opensuse/opensuse-42.1/opensuse-42.1-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-42.1/opensuse-42.1-base/Dockerfile
@@ -34,6 +34,7 @@ RUN zypper --non-interactive install python \
                    glibc-locale \
                    python3-xml \
                    python3-curses \
+                   sudo  \
                    libSDL-devel && \
     useradd -U -m yoctouser
 

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
         cpio \
         screen \
         tmux \
+        sudo \
         tightvncserver && \
     apt-get clean && \
     useradd -U -m yoctouser && \

--- a/dockerfiles/ubuntu/ubuntu-16.10/ubuntu-16.10-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.10/ubuntu-16.10-base/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
         cpio \
         screen \
         tmux \
+        sudo \
         tightvncserver && \
     apt-get clean && \
     useradd -U -m yoctouser && \


### PR DESCRIPTION
Add the sudo package to the containers that did not have it installed.
This is needed by the hoop jumping usersetup.py does.

Signed-off-by: brian avery <brian.avery@intel.com>