### PR TITLE
dockerfiles: add missing host tools to base

### DIFF
--- a/dockerfiles/opensuse/opensuse-13.2/opensuse-13.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-13.2/opensuse-13.2-base/Dockerfile
@@ -38,6 +38,8 @@ RUN zypper --non-interactive install python \
                    tmux \
                    sudo \
                    libSDL-devel \
+                   iproute2 \
+                   net-tools \
                    xorg-x11-Xvnc && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \

--- a/dockerfiles/opensuse/opensuse-42.1/opensuse-42.1-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-42.1/opensuse-42.1-base/Dockerfile
@@ -36,6 +36,8 @@ RUN zypper --non-interactive install python \
                    python3-curses \
                    sudo  \
                    libSDL-devel \
+                   iproute2 \
+                   net-tools \
                   xorg-x11-Xvnc && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \

--- a/dockerfiles/opensuse/opensuse-42.2/opensuse-42.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-42.2/opensuse-42.2-base/Dockerfile
@@ -36,6 +36,8 @@ RUN zypper --non-interactive install python \
                    python3-curses \
                    sudo  \
                    libSDL-devel  \
+                   iproute2 \
+                   net-tools \
                    xorg-x11-Xvnc && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && \
         screen \
         tmux \
         sudo \
+        iputils-ping \
         fluxbox \
         tightvncserver && \
     cp -af /etc/skel/ /etc/vncskel/ && \

--- a/dockerfiles/ubuntu/ubuntu-16.10/ubuntu-16.10-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.10/ubuntu-16.10-base/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && \
         screen \
         tmux \
         sudo \
+        iputils-ping \
         fluxbox \
         tightvncserver && \
     cp -af /etc/skel/ /etc/vncskel/ && \


### PR DESCRIPTION
bitbake now checks to see if we have a certain set of host tools
available for before it will launch a build. This check caught several
missing tools that are mostly used for testimage.  This commit adds
the missing tools.

What was missing:
opensuse-<all>  - hostname , ip
ubuntu-16-<all> - ping

Signed-off-by: brian avery <brian.avery@intel.com>