### PR TITLE
Add Zesty Zapus image and fix building behind a proxy

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -36,7 +36,14 @@ cd $workdir
 baseimage=`grep FROM Dockerfile | sed -e 's/FROM //'`
 docker pull $baseimage
 
-docker build -t $REPO:$TAG .
+docker build \
+       --build-arg http_proxy=$http_proxy \
+       --build-arg HTTP_PROXY=$http_proxy \
+       --build-arg https_proxy=$https_proxy \
+       --build-arg HTTPS_PROXY=$https_proxy \
+       --build-arg no_proxy=$no_proxy \
+       --build-arg NO_PROXY=$no_proxy \
+       -t $REPO:$TAG .
 rm $workdir -rf
 cd -
 
@@ -56,7 +63,14 @@ cd $workdir
 sed -i -e "s#crops/yocto#$REPO#" Dockerfile
 
 # Lastly build the image
-docker build -t $REPO:$TAG .
+docker build \
+       --build-arg http_proxy=$http_proxy \
+       --build-arg HTTP_PROXY=$http_proxy \
+       --build-arg https_proxy=$https_proxy \
+       --build-arg HTTPS_PROXY=$https_proxy \
+       --build-arg no_proxy=$no_proxy \
+       --build-arg NO_PROXY=$no_proxy \
+       -t $REPO:$TAG .
 cd -
 
 # base tests

--- a/dockerfiles/ubuntu/ubuntu-17.04/ubuntu-17.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-17.04/ubuntu-17.04-base/Dockerfile
@@ -1,0 +1,60 @@
+# ubuntu-17.04-base
+# Copyright (C) 2015-2017 Intel Corporation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+FROM ubuntu:17.04
+
+RUN apt-get update && \
+    apt-get install -y \
+        gawk \
+        wget \
+        git-core \
+        diffstat \
+        unzip \
+        sysstat \
+        texinfo \
+        gcc-multilib \
+        build-essential \
+        chrpath \
+        socat \
+        python \
+        python3 \
+        libsdl1.2-dev  \
+        xz-utils  \
+        locales \
+        cpio \
+        screen \
+        tmux \
+        sudo \
+        iputils-ping \
+        iproute2 \
+        fluxbox \
+        tightvncserver && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    useradd -U -m yoctouser && \
+    /usr/sbin/locale-gen en_US.UTF-8
+
+COPY build-install-dumb-init.sh /
+RUN  bash /build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh && \
+     apt-get clean
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash

--- a/dockerfiles/ubuntu/ubuntu-17.04/ubuntu-17.04-builder/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-17.04/ubuntu-17.04-builder/Dockerfile
@@ -1,0 +1,27 @@
+# ubuntu-17.04-builder
+# Copyright (C) 2015-2016 Intel Corporation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+FROM crops/yocto:ubuntu-17.04-base
+
+USER root
+COPY runbitbake.py /home/yoctouser/
+RUN chown -R yoctouser /home/yoctouser/ && \
+    chmod +x /home/yoctouser/runbitbake.py
+
+USER yoctouser
+
+WORKDIR /home/yoctouser
+ENTRYPOINT ["/home/yoctouser/runbitbake.py"]


### PR DESCRIPTION
I wanted to do some testing of the upcoming YP release with the impending Ubuntu 17.04 release and thought a container made perfect sense.

At the same time I had to figure out how to build docker images when I'm behind a proxy (https://github.com/crops/yocto-dockerfiles/issues/16). This small PR contains two patches, one to enable build_container.sh to better function when behind a proxy and another to add an Ubuntu 17.04 image.

The first patch is, IMHO, immediately useful whilst the second may want to wait until Ubuntu 17.04 is released?