### PR TITLE
smoke.sh: run smoke tests container as user uid

### DIFF
--- a/tests/container/smoke.sh
+++ b/tests/container/smoke.sh
@@ -34,17 +34,17 @@ chmod -R 777 $workdir
 
 # Ensure dumb-init is installed. This is to try and catch if
 # build-install-dumb-init.sh didn't work.
-docker run -t --rm --entrypoint=/bin/bash $image -c 'ls /usr/bin/dumb-init'
+docker run -t --rm --entrypoint=/bin/bash -u $(id -u):$(id -g) $image -c 'ls /usr/bin/dumb-init'
 
 # Try to build quilt-native which is small and fast to build.
 git clone --depth 1 --branch master \
           git://git.yoctoproject.org/poky $workdir/poky
-docker run -t --rm -v $workdir:/workdir $image --pokydir=$pokydir \
+docker run -t --rm -v $workdir:/workdir -u $(id -u):$(id -g) $image --pokydir=$pokydir \
            -b $builddir -t quilt-native
 
 # Since yoctouser in the container may create files that the travis user
 # can't delete, run the container again to delete the files in the directory.
-docker run -t --rm -v $workdir:/workdir --entrypoint=/bin/rm $image \
+docker run -t --rm -v $workdir:/workdir -u $(id -u):$(id -g) --entrypoint=/bin/rm $image \
            $builddir -rf
 
 rm $workdir -rf


### PR DESCRIPTION
Some of the smoke tests put files in the $workdir which is set to
/tmp/tmp.GUID_smoke. This workdir is mounted from the host into the
container. If the tests are successful, this directory's contents are
removed. Previously, these tests were running as the default user 1000
in the container so if you were uid=1010 on the system, the smoke tests
would drop files in /tmp/tmp.GUID_smoke owned by uid=1000 and the final
smoke test cleanup to remove all the files from the /tmp/tmp.GUID_smoke
would fail.  Similarly, it's better to run as the user uid in case they
want to edit/modify/whatever the files.

Signed-off-by: brian avery <brian.avery@intel.com>