### PR TITLE
opensuse-15.0: add gzip, bzip2; drop python3-xml

### DIFF
--- a/dockerfiles/opensuse/opensuse-15.0/opensuse-15.0-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.0/opensuse-15.0-base/Dockerfile
@@ -33,12 +33,13 @@ RUN zypper --non-interactive install python \
                    socat \
                    tar \
                    glibc-locale \
-                   python3-xml \
                    python3-curses \
                    sudo  \
                    iproute2 \
                    net-tools \
-                   xorg-x11-Xvnc && \
+                   xorg-x11-Xvnc \
+                   gzip \
+                   bzip2 && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
     mkdir  /etc/vncskel/.vnc && \


### PR DESCRIPTION
* Upstream container no longer has gzip
* HOSTTOOLS now requires bzip2, not in upstream container
* python3-xml is not needed, since expat xml is in core python3

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>