### PR TITLE
centos-7: Fix vnc test failure

### DIFF
--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -64,6 +64,10 @@ RUN  bash build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh && \
      yum -y clean all
 
+COPY vncserver.patch /
+RUN  patch /usr/bin/vncserver /vncserver.patch && \
+     rm /vncserver.patch
+
 USER yoctouser
 WORKDIR /home/yoctouser
 CMD /bin/bash

--- a/dockerfiles/centos/centos-7/centos-7-base/vncserver.patch
+++ b/dockerfiles/centos/centos-7/centos-7-base/vncserver.patch
@@ -1,0 +1,10 @@
+@@ -63,8 +63,7 @@
+     = ("#!/bin/sh\n\n".
+        "unset SESSION_MANAGER\n".
+        "unset DBUS_SESSION_BUS_ADDRESS\n".
+-       "/etc/X11/xinit/xinitrc\n".
+-       "vncserver -kill \$DISPLAY\n");
++       "/etc/X11/xinit/xinitrc\n");
+ 
+ $defaultConfig
+     = ("## Supported server options to pass to vncserver upon invocation can be listed\n".


### PR DESCRIPTION
Patch /usr/bin/vncserver to no longer run "vncserver -kill $DISPLAY".

The vnc smoke test was failing for Centos 7. For some reason the default
xstartup file created by /usr/bin/vncserver would run "vncserver -kill
$DISPAY".

This command is not in the upstream tigervnc and it was having the
effect of killing the vncserver right after it was started.

Signed-off-by: Randy Witt <randy.e.witt@intel.com>