### PR TITLE
ubuntu-14.04: Add realpath

### DIFF
--- a/dockerfiles/ubuntu/ubuntu-14.04/ubuntu-14.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-14.04/ubuntu-14.04-base/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && \
         screen \
         tmux \
         fluxbox \
+        realpath \
         tightvncserver && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \


### PR DESCRIPTION
realpath was added to HOSTTOOLS, so it is now needed in the image.

Signed-off-by: Randy Witt <randy.e.witt@intel.com>