### PR TITLE
Fix dumb-init tests on CentOS 7

### DIFF
--- a/build-install-dumb-init.sh
+++ b/build-install-dumb-init.sh
@@ -4,8 +4,8 @@ builddir=`mktemp -d` || exit 1
 cd $builddir || exit 1
 
 if grep -q CentOS /etc/*release; then
-    INSTALL_CMD="yum -y install python34-pip glibc-static"
-    REMOVE_CMD="yum -y remove python34-pip glibc-static"
+    INSTALL_CMD="yum -y install python36-pip glibc-static"
+    REMOVE_CMD="yum -y remove python36-pip glibc-static"
 elif grep -q Fedora /etc/*release; then
     INSTALL_CMD="dnf -y install glibc-static"
     REMOVE_CMD="dnf -y remove glibc-static"

--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -26,7 +26,7 @@ RUN yum -y install epel-release && \
         bzip2 \
         gzip \
         python \
-        python34 \
+        python36 \
         unzip \
         perl \
         patch \


### PR DESCRIPTION
Use python36 instead of python34.

This fixes the failures that were occurring due to "pip3" not being
found.

Signed-off-by: Randy Witt <randy.e.witt@intel.com>