### PR TITLE
test_runbitbake.py: Update to work with python3

### DIFF
--- a/tests/unit/test_runbitbake.py
+++ b/tests/unit/test_runbitbake.py
@@ -180,7 +180,8 @@ def test_signal_forward(bitbake_signal_path, tmpdir, pokydir, test_signal):
 
     p = subprocess.Popen(shlex.split(cmd),
                          stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT, shell=False)
+                         stderr=subprocess.STDOUT, shell=False,
+                         universal_newlines=True)
 
     # Wait til program is started before sending the signal
     count = 0


### PR DESCRIPTION
In python3 stdout for Popen() is a byte stream, so it must be decoded to
strings. This change is necessary because travis switched to python3.

Signed-off-by: Randy Witt <randy.e.witt@intel.com>