### PR TITLE
ubuntu-*: add libncurses5-dev

### DIFF
--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && \
         sudo \
         iputils-ping \
         fluxbox \
-        tightvncserver && \
+        tightvncserver \
+        libncurses5-dev && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
     mkdir  /etc/vncskel/.vnc && \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
         iputils-ping \
         iproute2 \
         fluxbox \
-        tightvncserver && \
+        tightvncserver \
+        libncurses5-dev && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
     mkdir  /etc/vncskel/.vnc && \

--- a/dockerfiles/ubuntu/ubuntu-19.04/ubuntu-19.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-19.04/ubuntu-19.04-base/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update && \
         iputils-ping \
         iproute2 \
         fluxbox \
-        tightvncserver && \
+        tightvncserver \
+        libncurses5-dev && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
     mkdir  /etc/vncskel/.vnc && \


### PR DESCRIPTION
Library required for menuconfig support for e.g. u-boot- and Linux kernel development. Topic has been mentioned multiple times in https://github.com/crops/poky-container - I hope it can be added here?

Ideally, it should be added to other distros, I don't have means for testing though.