### PR TITLE
Add repo tool to images

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -76,6 +76,7 @@ cd -
 
 # base tests
 ./tests/container/vnc-test.sh $REPO:$DISTRO_TO_BUILD-base
+./tests/container/repo-test.sh $REPO:$DISTRO_TO_BUILD-base
 # builder tests
 ./tests/container/smoke.sh $REPO:$DISTRO_TO_BUILD-builder
 

--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -56,6 +56,9 @@ RUN yum -y install epel-release && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     groupadd -g 1000 yoctouser && \
     useradd -u 1000 -g yoctouser -m yoctouser
 

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get clean && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser && \
     echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 

--- a/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
+++ b/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get clean && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser && \
     echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 

--- a/dockerfiles/fedora/fedora-28/fedora-28-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-28/fedora-28-base/Dockerfile
@@ -63,6 +63,9 @@ RUN dnf -y update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser
 
 COPY build-install-dumb-init.sh /

--- a/dockerfiles/fedora/fedora-29/fedora-29-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-29/fedora-29-base/Dockerfile
@@ -63,6 +63,9 @@ RUN dnf -y update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser
 
 COPY build-install-dumb-init.sh /

--- a/dockerfiles/fedora/fedora-30/fedora-30-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-30/fedora-30-base/Dockerfile
@@ -64,6 +64,9 @@ RUN dnf -y update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser
 
 COPY build-install-dumb-init.sh /

--- a/dockerfiles/opensuse/opensuse-15.0/opensuse-15.0-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.0/opensuse-15.0-base/Dockerfile
@@ -45,6 +45,9 @@ RUN zypper --non-interactive install python \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser
 
 COPY build-install-dumb-init.sh /

--- a/dockerfiles/opensuse/opensuse-15.1/opensuse-15.1-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.1/opensuse-15.1-base/Dockerfile
@@ -45,6 +45,9 @@ RUN zypper --non-interactive install python \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser
 
 COPY build-install-dumb-init.sh /

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -46,6 +46,9 @@ RUN apt-get update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser && \
     /usr/sbin/locale-gen en_US.UTF-8
 

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser && \
     /usr/sbin/locale-gen en_US.UTF-8
 

--- a/dockerfiles/ubuntu/ubuntu-19.04/ubuntu-19.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-19.04/ubuntu-19.04-base/Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get update && \
     mkdir  /etc/vncskel/.vnc && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
+    # Repo is a useful tool for checking out multiple git repos
+    wget https://storage.googleapis.com/git-repo-downloads/repo -O /usr/local/bin/repo && \
+    chmod +x /usr/local/bin/repo && \
     useradd -U -m yoctouser && \
     /usr/sbin/locale-gen en_US.UTF-8
 

--- a/tests/container/repo-test.sh
+++ b/tests/container/repo-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# repo-test
+#
+# Copyright (C) 2016 Intel Corporation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+set -e
+set -x
+
+
+# Pass in the image that was built for docker
+image=$1
+workdir=`mktemp -d --suffix=vnc`
+SCRIPT_DIR=$(dirname $(readlink -f $0))
+
+docker run -t --rm -v $workdir:/workdir \
+    $image repo help init
+rm $workdir -rf


### PR DESCRIPTION
The google repo tool helps manage projects with multiple git repos.
Some use it for yocto.

Closes: #22

Signed-off-by: Cormier, Jonathan <jcormier@criticallink.com>

Used by AGL and multiple teams internally.

Signed-off-by: Tim Orling <timothy.t.orling@linux.intel.com>