### PR TITLE
Improve Ubuntu/Debian container configs, add Ubuntu 20.04 and update buildtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - DISTRO_TO_BUILD=opensuse-15.1
     - DISTRO_TO_BUILD=ubuntu-16.04
     - DISTRO_TO_BUILD=ubuntu-18.04
+    - DISTRO_TO_BUILD=ubuntu-20.04
 
   global:
     - REPO=crops/yocto

--- a/build_container.sh
+++ b/build_container.sh
@@ -36,6 +36,7 @@ cp -r $dockerdir $workdir
 workdir=$workdir/$TAG
 
 cp build-install-dumb-init.sh $workdir
+cp install-buildtools.sh $workdir
 cd $workdir
 
 baseimage=`grep FROM Dockerfile | sed -e 's/FROM //'`

--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -14,13 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 
 # This entry point is so that we can do distro specific changes to the launch.
-if grep -q CentOS /etc/*release; then
-    # This is so that tar >= 1.28 can be used, which is required to pass the
-    # sanity checks as of poky commit 2c7624c17e43f9215cf7dcebf7258d28711bc3ce.
-    . /opt/poky/3.0/environment-setup-x86_64-pokysdk-linux || exit 1
-
-    # This is so that a gcc >= 5.0 will be used
-    . scl_source enable devtoolset-8 || exit 1
+if [ -e /opt/poky/3.1/environment-setup-x86_64-pokysdk-linux ]; then
+    # Buildtools has been installed so enable it
+    . /opt/poky/3.1/environment-setup-x86_64-pokysdk-linux || exit 1
 fi
 
 exec "$@"

--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -50,9 +50,7 @@ RUN yum -y install epel-release centos-release-scl && \
         screen \
         tmux \
         sudo \
-        devtoolset-8 \
         which && \
-    rm /opt/rh/devtoolset-8/root/usr/bin/sudo && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
     mkdir  /etc/vncskel/.vnc && \

--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -61,14 +61,12 @@ RUN yum -y install epel-release centos-release-scl && \
     groupadd -g 1000 yoctouser && \
     useradd -u 1000 -g yoctouser -m yoctouser
 
-# Install the buildtools-tarball so tar is a new enough version to satisy the
-# 1.28 requirment added by the 2c7624c17e43f9215cf7dcebf7258d28711bc3ce commit
-# to poky.
-RUN  wget http://downloads.yoctoproject.org/releases/yocto/yocto-3.0/buildtools/x86_64-buildtools-nativesdk-standalone-3.0.sh || exit 1 && \
-     echo "c2a077fa1be15d94bf9385a8d478a146 x86_64-buildtools-nativesdk-standalone-3.0.sh" > x86_64-buildtools-nativesdk-standalone-3.0.sh.md5sum || exit 1 && \
-     md5sum -c x86_64-buildtools-nativesdk-standalone-3.0.sh.md5sum || exit 1 && \
-     chmod +x x86_64-buildtools-nativesdk-standalone-3.0.sh || exit 1 && \
-     ./x86_64-buildtools-nativesdk-standalone-3.0.sh -y || exit 1
+# The versions of gcc, tar and other tools found in Centos 7 are now too old to
+# build recent Yocto Project releases. Install the buildtools tarball to
+# provide the required tools.
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh /
 RUN  bash build-install-dumb-init.sh && \

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:10
 
 RUN apt-get clean && \
     apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gawk \
         wget \
         git-core \

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get clean && \
         sysstat \
         texinfo \
         gcc-multilib \
+        g++-multilib \
         build-essential \
         chrpath \
         socat \

--- a/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
+++ b/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get clean && \
         sysstat \
         texinfo \
         gcc-multilib \
+        g++-multilib \
         build-essential \
         chrpath \
         socat \

--- a/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
+++ b/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
@@ -18,7 +18,7 @@ FROM debian:9
 
 RUN apt-get clean && \
     apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gawk \
         wget \
         git-core \

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
         sysstat \
         texinfo \
         gcc-multilib \
+        g++-multilib \
         build-essential \
         chrpath \
         socat \

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -52,6 +52,13 @@ RUN apt-get update && \
     echo 'dash dash/sh boolean false' | debconf-set-selections && \
     DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
+# The versions of gcc, tar and other tools found in Ubuntu 16.04 are now too
+# old to build recent Yocto Project releases. Install the buildtools tarball to
+# provide the required tools.
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
+
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh && \

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -17,7 +17,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gawk \
         wget \
         git-core \

--- a/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-16.04/ubuntu-16.04-base/Dockerfile
@@ -48,7 +48,9 @@ RUN apt-get update && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
     useradd -U -m yoctouser && \
-    /usr/sbin/locale-gen en_US.UTF-8
+    /usr/sbin/locale-gen en_US.UTF-8 && \
+    echo 'dash dash/sh boolean false' | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -17,7 +17,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
         gawk \
         wget \
         git-core \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
         sysstat \
         texinfo \
         gcc-multilib \
+        g++-multilib \
         build-essential \
         chrpath \
         socat \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -49,7 +49,9 @@ RUN apt-get update && \
     echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
     useradd -U -m yoctouser && \
-    /usr/sbin/locale-gen en_US.UTF-8
+    /usr/sbin/locale-gen en_US.UTF-8 && \
+    echo 'dash dash/sh boolean false' | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \

--- a/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
@@ -1,0 +1,63 @@
+# ubuntu-20.04-base
+# Copyright (C) 2020 Intel Corporation
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+FROM ubuntu:20.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        gawk \
+        wget \
+        git-core \
+        subversion \
+        diffstat \
+        unzip \
+        sysstat \
+        texinfo \
+        gcc-multilib \
+        g++-multilib \
+        build-essential \
+        chrpath \
+        socat \
+        python \
+        python3 \
+        xz-utils  \
+        locales \
+        cpio \
+        screen \
+        tmux \
+        sudo \
+        iputils-ping \
+        iproute2 \
+        fluxbox \
+        tightvncserver && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    useradd -U -m yoctouser && \
+    /usr/sbin/locale-gen en_US.UTF-8 && \
+    echo 'dash dash/sh boolean false' | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+
+COPY build-install-dumb-init.sh /
+RUN  bash /build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh && \
+     apt-get clean
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash

--- a/install-buildtools.sh
+++ b/install-buildtools.sh
@@ -2,12 +2,11 @@
 
 set -e
 
-wget http://downloads.yoctoproject.org/releases/yocto/yocto-3.0/buildtools/x86_64-buildtools-nativesdk-standalone-3.0.sh
+wget https://downloads.yoctoproject.org/releases/yocto/yocto-3.1/buildtools/x86_64-buildtools-extended-nativesdk-standalone-3.1.sh
 
-echo "c2a077fa1be15d94bf9385a8d478a146 x86_64-buildtools-nativesdk-standalone-3.0.sh" > x86_64-buildtools-nativesdk-standalone-3.0.sh.md5sum
-md5sum -c x86_64-buildtools-nativesdk-standalone-3.0.sh.md5sum
+echo "4fd00aee6a1e8d85920db8309ea10acb29cbfe9f411a4b127597aabf2013afd4  x86_64-buildtools-extended-nativesdk-standalone-3.1.sh" > SHA256SUMS
+sha256sum -c SHA256SUMS
+rm SHA256SUMS
 
-chmod +x x86_64-buildtools-nativesdk-standalone-3.0.sh
-./x86_64-buildtools-nativesdk-standalone-3.0.sh -y
-
-rm x86_64-buildtools-nativesdk-standalone-3.0.sh
+bash x86_64-buildtools-extended-nativesdk-standalone-3.1.sh -y
+rm x86_64-buildtools-extended-nativesdk-standalone-3.1.sh

--- a/install-buildtools.sh
+++ b/install-buildtools.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -e
+
+wget http://downloads.yoctoproject.org/releases/yocto/yocto-3.0/buildtools/x86_64-buildtools-nativesdk-standalone-3.0.sh
+
+echo "c2a077fa1be15d94bf9385a8d478a146 x86_64-buildtools-nativesdk-standalone-3.0.sh" > x86_64-buildtools-nativesdk-standalone-3.0.sh.md5sum
+md5sum -c x86_64-buildtools-nativesdk-standalone-3.0.sh.md5sum
+
+chmod +x x86_64-buildtools-nativesdk-standalone-3.0.sh
+./x86_64-buildtools-nativesdk-standalone-3.0.sh -y
+
+rm x86_64-buildtools-nativesdk-standalone-3.0.sh

--- a/tests/unit/test_runbitbake.py
+++ b/tests/unit/test_runbitbake.py
@@ -144,7 +144,7 @@ class AddExtraTest(RunBitbakeTestBase):
             localconflines = set(f.readlines())
 
         intersection = extraconflines & localconflines
-        self.assertListEqual(list(intersection), list(extraconflines))
+        self.assertListEqual(sorted(intersection), sorted(extraconflines))
 
 
 @pytest.fixture


### PR DESCRIPTION
* Improve the Debian & Ubuntu container configs to resolve issues seen with my use cases.
* Add a Dockerfile for Ubuntu 20.04
* Updated to buildtools-extended tarball from Yocto 3.1 for Centos 7 & Ubuntu 16.04.