### PR TITLE
timo/distro updates 7 2020: Add centos-8 and opensuse-15.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ services:
 env:
   matrix:
     - DISTRO_TO_BUILD=centos-7
+    - DISTRO_TO_BUILD=centos-8
     - DISTRO_TO_BUILD=debian-9
     - DISTRO_TO_BUILD=debian-10
     - DISTRO_TO_BUILD=fedora-31
     - DISTRO_TO_BUILD=fedora-32
     - DISTRO_TO_BUILD=opensuse-15.1
+    - DISTRO_TO_BUILD=opensuse-15.2
     - DISTRO_TO_BUILD=ubuntu-16.04
     - DISTRO_TO_BUILD=ubuntu-18.04
     - DISTRO_TO_BUILD=ubuntu-20.04

--- a/dockerfiles/centos/centos-8/centos-8-base/Dockerfile
+++ b/dockerfiles/centos/centos-8/centos-8-base/Dockerfile
@@ -1,0 +1,62 @@
+# centos-8-base
+# Copyright (C) 2015-2020 Intel Corporation
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+FROM centos:centos8
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled PowerTools && \
+    dnf -y install epel-release && \
+    dnf -y update && \
+    dnf -y install \
+        bzip2 \
+        chrpath \
+        cpp \
+        diffstat \
+        diffutils \
+        file \
+        gawk \
+        gcc \
+        gcc-c++ \
+        git \
+        glibc-devel \
+        glibc-langpack-en \
+        gzip \
+        make \
+        patch \
+        perl \
+        perl-Data-Dumper \
+        perl-Text-ParseWords \
+        perl-Thread-Queue \
+        python3 \
+        rpcgen \
+        screen \
+        socat \
+        subversion \
+        sudo \
+        tar \
+        texinfo \
+        tigervnc-server \
+        tmux \
+        unzip \
+        wget \
+        which \
+        xz && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    groupadd -g 1000 yoctouser && \
+    useradd -u 1000 -g yoctouser -m yoctouser
+
+COPY build-install-dumb-init.sh /
+RUN  bash build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh && \
+     dnf -y clean all
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash

--- a/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
@@ -1,0 +1,46 @@
+# opensuse-15.2-base
+# Copyright (C) 2015-2020 Intel Corporation
+#
+# SPDX-License-Identifier: GPL-2.0-only
+##
+
+FROM opensuse/leap:15.2
+
+RUN zypper --non-interactive install python \
+                   bzip2 \
+                   chrpath \
+                   diffstat \
+                   gcc \
+                   gcc-c++ \
+                   git \
+                   glibc-locale \
+                   gzip \
+                   iproute2 \
+                   make \
+                   makeinfo \
+                   net-tools \
+                   patch \
+                   python-curses \
+                   python-xml \
+                   python3 \
+                   python3-curses \
+                   socat \
+                   subversion \
+                   sudo  \
+                   tar \
+                   wget \
+                   xorg-x11-Xvnc && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    useradd -U -m yoctouser
+
+COPY build-install-dumb-init.sh /
+RUN  bash /build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash


### PR DESCRIPTION
Add centos-8 and opensuse-15.2
while we are at it, sort the packages in alphabetical order to make it easier to catch what is present/missing.