### PR TITLE
ubuntu: 20.04: Sync dependencies with Yocto Ref. Man.

### DIFF
--- a/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
@@ -31,6 +31,8 @@ RUN apt-get update && \
         socat \
         python \
         python3 \
+        python3-pip \
+        python3-pexpect \
         xz-utils  \
         locales \
         cpio \
@@ -38,6 +40,12 @@ RUN apt-get update && \
         tmux \
         sudo \
         iputils-ping \
+        python3-git \
+        python3-jinja2 \
+        libegl1-mesa \
+        libsdl1.2-dev \
+        pylint3 \
+        xterm \
         iproute2 \
         fluxbox \
         tightvncserver && \


### PR DESCRIPTION
A number of packages listed as "[Essentials](https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#ubuntu-packages)" in the Yocto Reference Manual are not in the Ubuntu image.

With this change, all the essential packages are installed in the image.