### PR TITLE
Ubuntu 20.04: Add Python venv

### DIFF
--- a/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
         python \
         python3 \
         python3-pip \
+        python3-venv \
         python3-pexpect \
         xz-utils  \
         locales \


### PR DESCRIPTION
Python virtual environments are used by a lot of tools to handle their
dependencies, so add it to the image

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>