### PR TITLE
Buildtools 3.1.13

### DIFF
--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -11,9 +11,9 @@ elif [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 # This entry point is so that we can do distro specific changes to the launch.
-if [ -e /opt/poky/3.1.3/${SETUPSCRIPT} ]; then
+if [ -e /opt/poky/3.1.13/${SETUPSCRIPT} ]; then
     # Buildtools has been installed so enable it
-    . /opt/poky/3.1.3/${SETUPSCRIPT} || exit 1
+    . /opt/poky/3.1.13/${SETUPSCRIPT} || exit 1
 fi
 
 exec "$@"

--- a/install-buildtools.sh
+++ b/install-buildtools.sh
@@ -9,18 +9,18 @@
 set -e
 
 if [ "$(uname -m)" = "aarch64" ]; then
-    BUILDTOOLS="aarch64-buildtools-extended-nativesdk-standalone-3.1.3.sh"
-    SHA256SUM="ea342902dafb53f6f7b7df948263a086b116cb0944051e930a8c1edae3ea3e0d"
+    BUILDTOOLS="aarch64-buildtools-extended-nativesdk-standalone-3.1.13.sh"
+    SHA256SUM="de63845b8d7d3bbd49ea96cd94be3df7ca6e935d0ab510d30c00fa35e3e5e6cd"
 elif [ "$(uname -m)" = "x86_64" ]; then
-    BUILDTOOLS="x86_64-buildtools-extended-nativesdk-standalone-3.1.3.sh"
-    SHA256SUM="809de42e33b86d964621752e914883077aeef7da4fe8c7f188669e222e739256"
+    BUILDTOOLS="x86_64-buildtools-extended-nativesdk-standalone-3.1.13.sh"
+    SHA256SUM="3f6a5e150de674d8098223ae1cfa26051b692d2ed04ce00ef247a836c36a0c41"
 else
     echo "Unsupported architecture, can't install buildtools."
     exit 1
 fi
 
 
-wget https://downloads.yoctoproject.org/releases/yocto/yocto-3.1.3/buildtools/${BUILDTOOLS}
+wget https://downloads.yoctoproject.org/releases/yocto/yocto-3.1.13/buildtools/${BUILDTOOLS}
 
 echo "${SHA256SUM} ${BUILDTOOLS}" > SHA256SUMS
 sha256sum -c SHA256SUMS


### PR DESCRIPTION
Older distros (centos-7, debian-9, ubuntu-16.04) are failing to run the dumb-init tox tests, because of an issue with the virtualenv and vendored _distutils in setuptools

```
tox
GLOB sdist-make: /tmp/tmp.fJuzCqLRn5/dumb-init-1.2.5/setup.py
py3 create: /tmp/tmp.fJuzCqLRn5/dumb-init-1.2.5/.tox/py3
ERROR: invocation failed (exit code 1), logfile: /tmp/tmp.fJuzCqLRn5/dumb-init-1.2.5/.tox/py3/log/py3-0.log
================================== log start ===================================
Traceback (most recent call last):
  File "/tmp/tmp.fJuzCqLRn5/venv/lib/python3.8/site-packages/setuptools/_distutils/util.py", line 258, in subst_vars
    return _subst_compat(s).format_map(lookup)
KeyError: 'LIBDEST'
```

This has since been corrected upstream, but it is still valuable to bump to the latest 'dunfell' 3.1.13 LTS buildtools-extended-tarball for bug and security fixes to the toolchains.