### PR TITLE
deploy.sh: Deploy when event is 'schedule'

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright (C) 2016-2021 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
@@ -14,7 +15,7 @@ fi
 
 # Don't deploy on pull requests because it could just be junk code that won't
 # get merged
-if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]) && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}"  = "schedule" ])  && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
     echo $DOCKER_PASSWORD | ${ENGINE_CMD} login -u $DOCKER_USERNAME --password-stdin
     ${ENGINE_CMD} push $REPO:$DISTRO_TO_BUILD-base
     ${ENGINE_CMD} push $REPO:$DISTRO_TO_BUILD-builder


### PR DESCRIPTION
Since 'github/workflows: build every Saturday at 00:52 UTC' builds were
properly being scheduled, but not deployed.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>