### PR TITLE
Drop centos-8 and replace with alma-8

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         distro_to_build: [
+          alma-8,
           centos-7,
-          centos-8,
           debian-9,
           debian-10,
           debian-11,

--- a/build-install-dumb-init.sh
+++ b/build-install-dumb-init.sh
@@ -7,10 +7,15 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+set -x
+
 builddir=`mktemp -d` || exit 1
 cd $builddir || exit 1
 
-if grep -q CentOS /etc/*release; then
+if grep -q Alma /etc/*release; then
+    INSTALL_CMD="dnf -y install glibc-static"
+    REMOVE_CMD="dnf -y remove glibc-static"
+elif grep -q CentOS /etc/*release; then
     INSTALL_CMD="yum -y install glibc-static"
     REMOVE_CMD="yum -y remove glibc-static"
 elif grep -q Fedora /etc/*release; then

--- a/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
+++ b/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
@@ -1,10 +1,11 @@
-# centos-8-base
+# alama-8-base
 # Copyright (C) 2015-2020 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
 #
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-FROM centos:centos8
+FROM almalinux:8
 
 RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled powertools && \
@@ -13,6 +14,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf -y install \
         bzip2 \
         chrpath \
+        cpio \
         cpp \
         diffstat \
         diffutils \
@@ -32,13 +34,11 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         perl-Text-ParseWords \
         perl-Thread-Queue \
         python3 \
-        rpcgen \
-        screen \
+	rpcgen \
         socat \
         subversion \
         sudo \
         tar \
-        texinfo \
         tigervnc-server \
         tmux \
         unzip \

--- a/tests/container/vnc-in-container-test.sh
+++ b/tests/container/vnc-in-container-test.sh
@@ -15,7 +15,9 @@ ls -al /workdir
 useradd -m --skel=/etc/vncskel vncuser
 
 # install xdpyinfo in the distros that are missing it
-if grep -q CentOS /etc/*release; then
+if grep -q Alma /etc/*release; then
+    dnf -y install xorg-x11-utils
+elif grep -q CentOS /etc/*release; then
     yum -y install xorg-x11-utils
 elif grep -q Fedora /etc/*release; then
     dnf -y install xorg-x11-utils


### PR DESCRIPTION
centos-8 can no longer fetch package repos, so drop it in favor of
almalinux.

centos-streams-8 has proven to be unstable on the Yocto Project
AutoBuilder so we will skip it. Not worth the headaches.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>