### PR TITLE
build-install-dumb-init.sh: pin setuptools==59.6.0

### DIFF
--- a/build-install-dumb-init.sh
+++ b/build-install-dumb-init.sh
@@ -56,7 +56,7 @@ pip3 install virtualenv || exit 1
 
 virtualenv $builddir/venv || exit 1
 . $builddir/venv/bin/activate || exit 1
-pip3 install tox || exit 1
+pip3 install setuptools==59.6.0 tox || exit 1
 )
 
 . $builddir/venv/bin/activate || exit 1


### PR DESCRIPTION
Automatic package discovery in newer setuptools fails with the following
error:

"""
GLOB sdist-make: /tmp/tmp.BST5jRIOuQ/dumb-init-1.2.5/setup.py
ERROR: invocation failed (exit code 1), logfile: /tmp/tmp.BST5jRIOuQ/dumb-init-1.2.5/.tox/log/GLOB-0.log
================================== log start ===================================
error: Multiple top-level packages discovered in a flat-layout: ['debian', 'testing'].

To avoid accidental inclusion of unwanted files or directories,
setuptools will not proceed with this build.

If you are trying to create a single distribution with multiple packages
on purpose, you should not rely on automatic discovery.
Instead, consider the following options:

1. set up custom discovery (`find` directive with `include` or `exclude`)
2. use a `src-layout`
3. explicitly set `py_modules` or `packages` with a list of names

To find more information, look for "package discovery" on setuptools docs.

=================================== log end ====================================
ERROR: FAIL could not package project - v = InvocationError('/tmp/tmp.BST5jRIOuQ/venv/bin/python setup.py sdist --formats=zip --dist-dir /tmp/tmp.BST5jRIOuQ/dumb-init-1.2.5/.tox/dist', 1)
"""

Filed an issue with upstream:
https://github.com/Yelp/dumb-init/issues/273

Signed-off-by: Tim Orling <tim.orling@konsulko.com>