### PR TITLE
install-buildtools-make: fix make 4.1.2 sanity check

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -28,6 +28,7 @@ workdir=$workdir/$TAG
 cp install-multilib.sh $workdir
 cp build-install-dumb-init.sh $workdir
 cp install-buildtools.sh $workdir
+cp install-buildtools-make.sh $workdir
 cd $workdir
 
 baseimage=`grep FROM Dockerfile | sed -e 's/FROM //'`

--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -14,6 +14,9 @@ fi
 if [ -e /opt/poky/3.1.13/${SETUPSCRIPT} ]; then
     # Buildtools has been installed so enable it
     . /opt/poky/3.1.13/${SETUPSCRIPT} || exit 1
+elif [ -e /opt/poky/4.0/${SETUPSCRIPT} ]; then
+    # Buildtools(-make) has been installed so enable it
+    . /opt/poky/4.0/${SETUPSCRIPT} || exit 1
 fi
 
 exec "$@"

--- a/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
+++ b/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
@@ -54,6 +54,12 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     groupadd -g 1000 yoctouser && \
     useradd -u 1000 -g yoctouser -m yoctouser
 
+# Install buildtools-make. The original reason this was needed was due to a
+# sanity check for make 4.1.2
+COPY install-buildtools-make.sh /
+RUN bash /install-buildtools-make.sh && \
+    rm /install-buildtools-make.sh
+
 COPY build-install-dumb-init.sh /
 RUN  bash build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh && \

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -41,6 +41,12 @@ RUN apt-get clean && \
     useradd -U -m yoctouser && \
     echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 
+# Install buildtools-make. The original reason this was needed was due to a
+# sanity check for make 4.1.2
+COPY install-buildtools-make.sh /
+RUN bash /install-buildtools-make.sh && \
+    rm /install-buildtools-make.sh
+
 COPY build-install-dumb-init.sh install-multilib.sh /
 RUN  bash /build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh && \

--- a/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM opensuse/leap:15.2
 
-RUN zypper --non-interactive install python \
+RUN zypper --non-interactive install \
                    bzip2 \
                    chrpath \
                    diffstat \
@@ -16,11 +16,12 @@ RUN zypper --non-interactive install python \
                    glibc-locale \
                    gzip \
                    iproute2 \
-		   lz4 \
+                   lz4 \
                    make \
                    makeinfo \
                    net-tools \
                    patch \
+                   python \
                    python-curses \
                    python-xml \
                    python3 \
@@ -31,6 +32,7 @@ RUN zypper --non-interactive install python \
                    tar \
                    wget \
                    xorg-x11-Xvnc \
+                   xz \
                    zstd && \
     cp -af /etc/skel/ /etc/vncskel/ && \
     echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \

--- a/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
@@ -39,6 +39,12 @@ RUN zypper --non-interactive install python \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
     useradd -U -m yoctouser
 
+# Install buildtools-make. The original reason this was needed was due to a
+# sanity check for make 4.1.2
+COPY install-buildtools-make.sh /
+RUN bash /install-buildtools-make.sh && \
+    rm /install-buildtools-make.sh
+
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh

--- a/install-buildtools-make.sh
+++ b/install-buildtools-make.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+# install-buildtools-make.sh
+#
+# Copyright (C) 2020-2021 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+set -e
+
+RELEASE="4.0"
+if [ "$(uname -m)" = "aarch64" ]; then
+    BUILDTOOLS="aarch64-buildtools-make-nativesdk-standalone-${RELEASE}.sh"
+    SHA256SUM="a6b1cd89b7b5d8d7ea540c2d6c101ef84fd8c78a125e407b6b3ad8427f5a64f3"
+elif [ "$(uname -m)" = "x86_64" ]; then
+    BUILDTOOLS="x86_64-buildtools-make-nativesdk-standalone-${RELEASE}.sh"
+    SHA256SUM="79ce0518e1b60cb854d3701350179f471a2a781ae695045ff13a62995923dbce"
+else
+    echo "Unsupported architecture, can't install buildtools-make."
+    exit 1
+fi
+
+# FIXME: temporarily use pre-release URL
+wget https://autobuilder.yocto.io/pub/non-release/20220413-28/buildtools/${BUILDTOOLS}
+# wget https://downloads.yoctoproject.org/releases/yocto/yocto-${RELEASE}/buildtools/${BUILDTOOLS}
+
+echo "${SHA256SUM} ${BUILDTOOLS}" > SHA256SUMS
+sha256sum -c SHA256SUMS
+rm SHA256SUMS
+
+bash ${BUILDTOOLS} -y
+rm ${BUILDTOOLS}


### PR DESCRIPTION
For alma-8, debian-10 and opensuse-15.2, with the 'kirkstone' Yocto
Project 4.0 release a new sanity check for make 4.1.2 is throwing an
error causing the containers to fail to build.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>