### PR TITLE
Fedora: add fedora-36

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -26,6 +26,7 @@ jobs:
           debian-11,
           fedora-34,
           fedora-35,
+          fedora-36,
           opensuse-15.2,
           opensuse-15.3,
           ubuntu-18.04,

--- a/dockerfiles/fedora/fedora-36/fedora-36-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-36/fedora-36-base/Dockerfile
@@ -1,0 +1,81 @@
+# fedora-36-base
+# Copyright (C) 2021 Intel Corporation
+# Copyright (C) 2021-2022 Konsulko Group
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+FROM fedora:36
+
+RUN dnf -y update && \
+    dnf -y install \
+	# These packages were copied straight from the Yocto Project reference
+        # manual which is why they are not alphabetized 
+        gawk \
+        make \
+        wget \
+        tar \
+        bzip2 \
+        gzip \
+        python3 \
+        unzip \
+        perl \
+        patch \
+        diffutils \
+        diffstat \
+        git \
+        cpp \
+        gcc \
+        gcc-c++ \
+        glibc-devel \
+        texinfo \
+        chrpath \
+        ccache \
+        perl-Data-Dumper \
+        perl-Text-ParseWords \
+        perl-Thread-Queue \
+        perl-bignum \
+        socat \
+        python3-pexpect \
+        findutils \
+        which \
+        file \
+        cpio \
+        python \
+        python3-pip \
+        xz \
+        python3-GitPython \
+        python3-jinja2 \
+        SDL-devel \
+        xterm \
+        rpcgen \
+	lz4 \
+	zstd \
+        \
+        # These packages were added because of reasons such as fewer packages
+        # being in the container image by default
+        fluxbox \
+        glibc-langpack-en \
+        hostname \
+        procps \
+        python-unversioned-command \
+        subversion \
+        sudo \
+        screen \
+        tigervnc-server \
+        tmux && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    useradd -U -m yoctouser
+
+COPY build-install-dumb-init.sh /
+RUN  bash /build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh && \
+     dnf -y clean all
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash


### PR DESCRIPTION
Fedora 36 was released on May 10, 2022

https://fedoraproject.org/wiki/Releases/36/ChangeSet
https://docs.fedoraproject.org/en-US/fedora/latest/
https://fedoramagazine.org/announcing-fedora-36/

Signed-off-by: Tim Orling <tim.orling@konsulko.com>