### PR TITLE
Alma: add alma-9

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         distro_to_build: [
           alma-8,
+          alma-9,
           centos-7,
           debian-9,
           debian-10,

--- a/dockerfiles/alma/alma-9/alma-9-base/Dockerfile
+++ b/dockerfiles/alma/alma-9/alma-9-base/Dockerfile
@@ -1,0 +1,77 @@
+# alama-9-base
+# Copyright (C) 2015-2020 Intel Corporation
+# Copyright (C) 2022 Konsulko Group
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+FROM almalinux:9
+
+RUN dnf install -y 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y update && \
+    dnf -y install \
+        bzip2 \
+        ccache \
+        chrpath \
+        cpio \
+        cpp \
+        diffstat \
+        diffutils \
+        file \
+        gawk \
+        gcc \
+        gcc-c++ \
+        git \
+        glibc-devel \
+        glibc-langpack-en \
+        gzip \
+        lz4 \
+        make \
+        patch \
+        perl \
+        perl-Data-Dumper \
+        perl-Text-ParseWords \
+        perl-Thread-Queue \
+        procps \
+        python3 \
+        python3-GitPython \
+        python3-jinja2 \
+        python3-pexpect \
+        python3-pip \
+        rpcgen \
+        socat \
+        subversion \
+        sudo \
+        tar \
+        texinfo \
+        tigervnc-server \
+        tmux \
+        unzip \
+        wget \
+        which \
+        xz \
+        zstd && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    groupadd -g 1000 yoctouser && \
+    useradd -u 1000 -g yoctouser -m yoctouser
+
+# Install buildtools-make. The original reason this was needed was due to a
+# sanity check for make 4.1.2
+COPY install-buildtools-make.sh /
+RUN bash /install-buildtools-make.sh && \
+    rm /install-buildtools-make.sh
+
+COPY build-install-dumb-init.sh /
+RUN  bash build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh && \
+     dnf -y clean all
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash


### PR DESCRIPTION
AlmaLinux 9 has been released for a while now
https://almalinux.org/blog/almalinux-9-now-available/ https://wiki.almalinux.org/release-notes/9.0.html

powertools is now known as crb
https://almalinux.discourse.group/t/powertools-on-almalinux-9/1296

Signed-off-by: Tim Orling <tim.orling@konsulko.com>