### PR TITLE
all: install python3-pip

### DIFF
--- a/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
+++ b/dockerfiles/centos/centos-7/centos-7-base/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y install epel-release centos-release-scl && \
         gzip \
         python \
         python3 \
+	python3-pip \
         unzip \
         perl \
         patch \

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -20,8 +20,9 @@ RUN apt-get clean && \
         build-essential \
         chrpath \
         socat \
-        python \
+	python \
         python3 \
+	python3-pip \
         cpio \
         xz-utils \
         locales \

--- a/dockerfiles/debian/debian-11/debian-11-base/Dockerfile
+++ b/dockerfiles/debian/debian-11/debian-11-base/Dockerfile
@@ -19,8 +19,9 @@ RUN apt-get clean && \
         locales \
 	lz4 \
         procps \
-        python \
+	python \
         python3 \
+	python3-pip \
         screen \
         socat \
         subversion \

--- a/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
+++ b/dockerfiles/debian/debian-9/debian-9-base/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get clean && \
         socat \
         python \
         python3 \
+	python3-pip \
         cpio \
         xz-utils \
         locales \

--- a/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
@@ -26,6 +26,7 @@ RUN zypper --non-interactive install \
                    python-xml \
                    python3 \
                    python3-curses \
+		   python3-pip \
                    socat \
                    subversion \
                    sudo  \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && \
         socat \
         python \
         python3 \
+	python3-pip \
         xz-utils  \
         locales \
         cpio \


### PR DESCRIPTION
python3-pip has been a requirement in the Yocto Project docs for a while now. Be consistent and install it in all the distro/versions.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>