### PR TITLE
Fix CI build breakage.

### DIFF
--- a/distro-entry.sh
+++ b/distro-entry.sh
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
+RELEASE="4.1"
+
 if [ "$(uname -m)" = "aarch64" ]; then
     SETUPSCRIPT="environment-setup-aarch64-pokysdk-linux"
 elif [ "$(uname -m)" = "x86_64" ]; then
@@ -11,12 +13,12 @@ elif [ "$(uname -m)" = "x86_64" ]; then
 fi
 
 # This entry point is so that we can do distro specific changes to the launch.
-if [ -e /opt/poky/3.1.13/${SETUPSCRIPT} ]; then
+if [ -e /opt/poky/${RELEASE}/${SETUPSCRIPT} ]; then
     # Buildtools has been installed so enable it
-    . /opt/poky/3.1.13/${SETUPSCRIPT} || exit 1
-elif [ -e /opt/poky/4.0/${SETUPSCRIPT} ]; then
+    . /opt/poky/${RELEASE}/${SETUPSCRIPT} || exit 1
+elif [ -e /opt/poky/${RELEASE}/${SETUPSCRIPT} ]; then
     # Buildtools(-make) has been installed so enable it
-    . /opt/poky/4.0/${SETUPSCRIPT} || exit 1
+    . /opt/poky/${RELEASE}/${SETUPSCRIPT} || exit 1
 fi
 
 exec "$@"

--- a/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
+++ b/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
@@ -61,11 +61,13 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     groupadd -g 1000 yoctouser && \
     useradd -u 1000 -g yoctouser -m yoctouser
 
-# Install buildtools-make. The original reason this was needed was due to a
-# sanity check for make 4.1.2
-COPY install-buildtools-make.sh /
-RUN bash /install-buildtools-make.sh && \
-    rm /install-buildtools-make.sh
+# Install buildtools. The original reason this was needed was due to a
+# sanity check for make 4.1.2, but now we're relying on python-3.8 so instead
+# of -make, install all the buildtools
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh /
 RUN  bash build-install-dumb-init.sh && \

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -42,11 +42,13 @@ RUN apt-get clean && \
     useradd -U -m yoctouser && \
     echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 
-# Install buildtools-make. The original reason this was needed was due to a
-# sanity check for make 4.1.2
-COPY install-buildtools-make.sh /
-RUN bash /install-buildtools-make.sh && \
-    rm /install-buildtools-make.sh
+# Install buildtools. The original reason this was needed was due to a
+# sanity check for make 4.1.2, but now we're relying on python-3.8 so instead
+# of -make, install all the buildtools
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh install-multilib.sh /
 RUN  bash /build-install-dumb-init.sh && \

--- a/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.2/opensuse-15.2-base/Dockerfile
@@ -42,11 +42,13 @@ RUN zypper --non-interactive install \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
     useradd -U -m yoctouser
 
-# Install buildtools-make. The original reason this was needed was due to a
-# sanity check for make 4.1.2
-COPY install-buildtools-make.sh /
-RUN bash /install-buildtools-make.sh && \
-    rm /install-buildtools-make.sh
+# Install buildtools. The original reason this was needed was due to a
+# sanity check for make 4.1.2, but now we're relying on python-3.8 so instead
+# of -make, install all the buildtools
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \

--- a/dockerfiles/opensuse/opensuse-15.3/opensuse-15.3-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.3/opensuse-15.3-base/Dockerfile
@@ -48,11 +48,13 @@ RUN zypper --non-interactive install \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
     useradd -U -m yoctouser
 
-# Install buildtools-make. The original reason this was needed was due to a
-# sanity check for make 4.2.1
-COPY install-buildtools-make.sh /
-RUN bash /install-buildtools-make.sh && \
-    rm /install-buildtools-make.sh
+# Install buildtools. The original reason this was needed was due to a
+# sanity check for make 4.1.2, but now we're relying on python-3.8 so instead
+# of -make, install all the buildtools
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \

--- a/dockerfiles/opensuse/opensuse-15.4/opensuse-15.4-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.4/opensuse-15.4-base/Dockerfile
@@ -48,11 +48,13 @@ RUN zypper --non-interactive install \
     chmod 0600 /etc/vncskel/.vnc/passwd && \
     useradd -U -m yoctouser
 
-# Install buildtools-make. The original reason this was needed was due to a
-# sanity check for make 4.2.1
-COPY install-buildtools-make.sh /
-RUN bash /install-buildtools-make.sh && \
-    rm /install-buildtools-make.sh
+# Install buildtools. The original reason this was needed was due to a
+# sanity check for make 4.1.2, but now we're relying on python-3.8 so instead
+# of -make, install all the buildtools
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -44,6 +44,12 @@ RUN apt-get update && \
     echo 'dash dash/sh boolean false' | debconf-set-selections && \
     DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
+# Install buildtools due to python 3.8
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
+
 COPY build-install-dumb-init.sh install-multilib.sh /
 RUN  bash /build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh && \

--- a/install-buildtools-make.sh
+++ b/install-buildtools-make.sh
@@ -9,21 +9,19 @@
 #
 set -e
 
-RELEASE="4.0"
+RELEASE="4.1"
 if [ "$(uname -m)" = "aarch64" ]; then
     BUILDTOOLS="aarch64-buildtools-make-nativesdk-standalone-${RELEASE}.sh"
-    SHA256SUM="a6b1cd89b7b5d8d7ea540c2d6c101ef84fd8c78a125e407b6b3ad8427f5a64f3"
+    SHA256SUM="ed241869743ac795d1a988246953df5931f68c22108d6f86ebc485b773d28db4"
 elif [ "$(uname -m)" = "x86_64" ]; then
     BUILDTOOLS="x86_64-buildtools-make-nativesdk-standalone-${RELEASE}.sh"
-    SHA256SUM="79ce0518e1b60cb854d3701350179f471a2a781ae695045ff13a62995923dbce"
+    SHA256SUM="d9cc8a4f76392e23f9b2854af78d460e99bb5e4cbb82de6ccca0f6be7506f652"
 else
     echo "Unsupported architecture, can't install buildtools-make."
     exit 1
 fi
 
-# FIXME: temporarily use pre-release URL
-wget https://autobuilder.yocto.io/pub/non-release/20220413-28/buildtools/${BUILDTOOLS}
-# wget https://downloads.yoctoproject.org/releases/yocto/yocto-${RELEASE}/buildtools/${BUILDTOOLS}
+wget https://downloads.yoctoproject.org/releases/yocto/yocto-${RELEASE}/buildtools/${BUILDTOOLS}
 
 echo "${SHA256SUM} ${BUILDTOOLS}" > SHA256SUMS
 sha256sum -c SHA256SUMS

--- a/install-buildtools.sh
+++ b/install-buildtools.sh
@@ -8,19 +8,19 @@
 #
 set -e
 
+RELEASE="4.1"
 if [ "$(uname -m)" = "aarch64" ]; then
-    BUILDTOOLS="aarch64-buildtools-extended-nativesdk-standalone-3.1.13.sh"
-    SHA256SUM="de63845b8d7d3bbd49ea96cd94be3df7ca6e935d0ab510d30c00fa35e3e5e6cd"
+    BUILDTOOLS="aarch64-buildtools-extended-nativesdk-standalone-${RELEASE}.sh"
+    SHA256SUM="d5c0dd3e43c62f0465a9335f450d9f5f6861e4b3d39b0f04174bd50e6861c96e"
 elif [ "$(uname -m)" = "x86_64" ]; then
-    BUILDTOOLS="x86_64-buildtools-extended-nativesdk-standalone-3.1.13.sh"
-    SHA256SUM="3f6a5e150de674d8098223ae1cfa26051b692d2ed04ce00ef247a836c36a0c41"
+    BUILDTOOLS="x86_64-buildtools-extended-nativesdk-standalone-${RELEASE}.sh"
+    SHA256SUM="d360ac01016c848f713d6dd7848f25d0a5319e96e2dd279ab37ffcbd7320dbbe"
 else
-    echo "Unsupported architecture, can't install buildtools."
+    echo "Unsupported architecture, can't install buildtools-make."
     exit 1
 fi
 
-
-wget https://downloads.yoctoproject.org/releases/yocto/yocto-3.1.13/buildtools/${BUILDTOOLS}
+wget https://downloads.yoctoproject.org/releases/yocto/yocto-${RELEASE}/buildtools/${BUILDTOOLS}
 
 echo "${SHA256SUM} ${BUILDTOOLS}" > SHA256SUMS
 sha256sum -c SHA256SUMS


### PR DESCRIPTION
This patchset fixes the CI build breakage seen with the addition of the python 3.8 dependency and the missing make-nativesdk-standalone binaries we were pulling from the autobuilder. It also upgrades to installed buildtools to the most recent buildtools (4.1).