### PR TITLE
Deploy to ghcr.io

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +42,8 @@ jobs:
       REPO: crops/yocto
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      GHCR_USERNAME: ${{ github.actor }}
+      GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,4 +19,11 @@ if ([ "${GITHUB_EVENT_NAME}" = "push" ] || [ "${GITHUB_EVENT_NAME}" = "workflow_
     echo $DOCKER_PASSWORD | ${ENGINE_CMD} login -u $DOCKER_USERNAME --password-stdin
     ${ENGINE_CMD} push $REPO:$DISTRO_TO_BUILD-base
     ${ENGINE_CMD} push $REPO:$DISTRO_TO_BUILD-builder
+
+    ${ENGINE_CMD} tag $REPO:$DISTRO_TO_BUILD-base ghcr.io/$REPO:$DISTRO_TO_BUILD-base
+    ${ENGINE_CMD} tag $REPO:$DISTRO_TO_BUILD-builder ghcr.io/$REPO:$DISTRO_TO_BUILD-builder
+
+    echo $GHCR_PASSWORD | ${ENGINE_CMD} login ghcr.io -u $GHCR_USERNAME --password-stdin
+    ${ENGINE_CMD} push ghcr.io/$REPO:$DISTRO_TO_BUILD-base
+    ${ENGINE_CMD} push ghcr.io/$REPO:$DISTRO_TO_BUILD-builder
 fi


### PR DESCRIPTION
This deployment process has been tested on my GitHub account using an extra commit to change the destination repo and not push to Docker Hub: https://github.com/pbrkr/yocto-dockerfiles/commit/74021a4badb7d9b447d4a577901da7bc75c54b98

The action results are all good there: https://github.com/pbrkr/yocto-dockerfiles/actions/runs/3928894387

And the containers are visible within my user account: https://github.com/pbrkr/yocto-dockerfiles/pkgs/container/yocto/versions

This *should* work when merged to the main `yocto-dockerfiles` repo but deployments are one of those things that's not possible to perfectly test before merging. Please ping me on IRC before merging this so we can check the results and I can jump in and fix things if there is an issue.

Once this deployment process is confirmed working for `yocto-dockerfiles` I'll move on to looking at the other repositories.