### PR TITLE
build_container.sh: add missing continuation char

### DIFF
--- a/build_container.sh
+++ b/build_container.sh
@@ -74,10 +74,10 @@ ${ENGINE_CMD} build \
 cd -
 
 # base tests
-ENGINE_CMD=${ENGINE_CMD}
+ENGINE_CMD=${ENGINE_CMD} \
     ./tests/container/vnc-test.sh $REPO:$DISTRO_TO_BUILD-base
 # builder tests
-ENGINE_CMD=${ENGINE_CMD}
+ENGINE_CMD=${ENGINE_CMD} \
     ./tests/container/smoke.sh $REPO:$DISTRO_TO_BUILD-builder
 
 rm $workdir -rf


### PR DESCRIPTION
When the ENGINE_CMD variable was introduced, the continuation character was missed in two places. Therefore that variable is passed neither in vnc-test.sh, nor in smoke.sh
So in this PR the issue would be fixed.