### PR TITLE
Debian: add debian-12 (bookworm)

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -26,6 +26,7 @@ jobs:
           centos-7,
           debian-10,
           debian-11,
+	  debian-12,
           fedora-36,
           opensuse-15.4,
           ubuntu-18.04,
@@ -45,7 +46,7 @@ jobs:
       GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Build and test the images
       - name: Run build-and-test.sh

--- a/dockerfiles/debian/debian-12/debian-12-base/Dockerfile
+++ b/dockerfiles/debian/debian-12/debian-12-base/Dockerfile
@@ -1,0 +1,61 @@
+# debian-12-base
+# Copyright (C) 2015-2021 Intel Corporation
+# Copyright (C) 2024 Konsulko Group
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+
+FROM debian:12
+
+ARG TARGETPLATFORM
+
+RUN apt-get clean && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        build-essential \
+        chrpath \
+        cpio \
+        diffstat \
+        fluxbox \
+        gawk \
+        git-core \
+        locales \
+	lz4 \
+        procps \
+        python3 \
+	python3-pip \
+        screen \
+        socat \
+        subversion \
+        sudo \
+        sysstat \
+        texinfo \
+        tightvncserver \
+        tmux \
+        unzip \
+        wget \
+        xz-utils \
+	zstd && \
+    case ${TARGETPLATFORM} in \
+        "linux/amd64") \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y \
+                gcc-multilib \
+                g++-multilib \
+            ;; \
+    esac && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    useradd -U -m yoctouser && \
+    echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
+
+COPY build-install-dumb-init.sh  /
+RUN  bash /build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh && \
+     apt-get clean
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash


### PR DESCRIPTION
https://wiki.debian.org/DebianBookworm
https://www.debian.org/releases/bookworm/

Debian 12.5 was released on February 10th, 2024. Debian 12.0 was initially released on June 10th, 2023.

https://endoflife.date/debian

Debian Security Support
Ends in 2 years and 3 months
(10 Jun 2026)

Debian LTS
Ends in 4 years
(10 Jun 2028)