### PR TITLE
OpenSUSE: add opensuse 15.6

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -30,6 +30,7 @@ jobs:
           fedora-40,
           opensuse-15.4,
           opensuse-15.5,
+          opensuse-15.6,
           ubuntu-18.04,
           ubuntu-20.04,
           ubuntu-22.04,

--- a/dockerfiles/opensuse/opensuse-15.5/opensuse-15.5-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.5/opensuse-15.5-base/Dockerfile
@@ -25,10 +25,10 @@ RUN zypper --non-interactive install \
                    net-tools \
                    patch \
                    python3 \
-		   python3-Jinja2 \
+                   python3-Jinja2 \
                    python3-curses \
-		   python3-pexpect \
-		   python3-pip \
+                   python3-pexpect \
+                   python3-pip \
                    python3-virtualenv \
                    rpcgen \
                    socat \

--- a/dockerfiles/opensuse/opensuse-15.6/opensuse-15.6-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.6/opensuse-15.6-base/Dockerfile
@@ -1,0 +1,64 @@
+# opensuse-15.6-base
+# Copyright (C) 2015-2020 Intel Corporation
+# Copyright (C) 2022-2024 Konsulko Group
+#
+# SPDX-License-Identifier: GPL-2.0-only
+##
+
+FROM opensuse/leap:15.6
+
+# Keep these in alphabetical order, as sorted by vim :sort
+RUN zypper --non-interactive install \
+                   bzip2 \
+                   chrpath \
+                   diffstat \
+                   gcc \
+                   gcc-c++ \
+                   git \
+                   glibc-locale \
+                   gzip \
+                   hostname \
+                   iproute2 \
+                   libacl1 \
+                   lz4 \
+                   make \
+                   makeinfo \
+                   net-tools \
+                   patch \
+                   python3 \
+                   python3-Jinja2 \
+                   python3-curses \
+                   python3-pexpect \
+                   python3-pip \
+                   python3-virtualenv \
+                   rpcgen \
+                   socat \
+                   subversion \
+                   sudo \
+                   tar \
+                   wget \
+                   xorg-x11-Xvnc \
+                   xz \
+                   zstd && \
+    cp -af /etc/skel/ /etc/vncskel/ && \
+    echo "export DISPLAY=1" >>/etc/vncskel/.bashrc && \
+    mkdir  /etc/vncskel/.vnc && \
+    echo "" | vncpasswd -f > /etc/vncskel/.vnc/passwd && \
+    chmod 0600 /etc/vncskel/.vnc/passwd && \
+    useradd -U -m yoctouser
+
+# Install buildtools. The original reason this was needed was due to a
+# sanity check for make 4.1.2, but now we're relying on python-3.8 so instead
+# of -make, install all the buildtools
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
+
+COPY build-install-dumb-init.sh /
+RUN  bash /build-install-dumb-init.sh && \
+     rm /build-install-dumb-init.sh
+
+USER yoctouser
+WORKDIR /home/yoctouser
+CMD /bin/bash


### PR DESCRIPTION
    https://en.opensuse.org/Release_announcement_15.6
    https://get.opensuse.org/leap/15.6/
    https://doc.opensuse.org/release-notes/x86_64/openSUSE/Leap/15.6/

    The following distributions are expected to receive updates until the specified date:

    openSUSE Leap 15.6 - is expected to be maintained until at least end of December 2025
    openSUSE Leap 15.5 - is expected to be maintained until end of December 2024