### PR TITLE
Add git large file support package

### DIFF
--- a/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
+++ b/dockerfiles/alma/alma-8/alma-8-base/Dockerfile
@@ -24,6 +24,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         gcc \
         gcc-c++ \
         git \
+        git-lfs \
         glibc-devel \
         glibc-langpack-en \
         gzip \

--- a/dockerfiles/alma/alma-9/alma-9-base/Dockerfile
+++ b/dockerfiles/alma/alma-9/alma-9-base/Dockerfile
@@ -24,6 +24,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         gcc \
         gcc-c++ \
         git \
+        git-lfs \
         glibc-devel \
         glibc-langpack-en \
         gzip \

--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get clean && \
         fluxbox \
         gawk \
         git-core \
+        git-lfs \
         locales \
         lz4 \
         procps \

--- a/dockerfiles/debian/debian-11/debian-11-base/Dockerfile
+++ b/dockerfiles/debian/debian-11/debian-11-base/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get clean && \
         fluxbox \
         gawk \
         git-core \
+        git-lfs \
         locales \
         lz4 \
         procps \

--- a/dockerfiles/debian/debian-12/debian-12-base/Dockerfile
+++ b/dockerfiles/debian/debian-12/debian-12-base/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get clean && \
         fluxbox \
         gawk \
         git-core \
+        git-lfs \
         locales \
         lz4 \
         procps \

--- a/dockerfiles/fedora/fedora-39/fedora-39-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-39/fedora-39-base/Dockerfile
@@ -55,6 +55,7 @@ RUN dnf -y update && \
         # These packages were added because of reasons such as fewer packages
         # being in the container image by default
         fluxbox \
+        git-lfs \
         glibc-langpack-en \
         hostname \
         procps \

--- a/dockerfiles/fedora/fedora-40/fedora-40-base/Dockerfile
+++ b/dockerfiles/fedora/fedora-40/fedora-40-base/Dockerfile
@@ -55,6 +55,7 @@ RUN dnf -y update && \
         # These packages were added because of reasons such as fewer packages
         # being in the container image by default
         fluxbox \
+        git-lfs \
         glibc-langpack-en \
         hostname \
         procps \

--- a/dockerfiles/opensuse/opensuse-15.4/opensuse-15.4-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.4/opensuse-15.4-base/Dockerfile
@@ -15,6 +15,7 @@ RUN zypper --non-interactive install \
                    gcc \
                    gcc-c++ \
                    git \
+                   git-lfs \
                    glibc-locale \
                    gzip \
                    iproute2 \

--- a/dockerfiles/opensuse/opensuse-15.5/opensuse-15.5-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.5/opensuse-15.5-base/Dockerfile
@@ -15,6 +15,7 @@ RUN zypper --non-interactive install \
                    gcc \
                    gcc-c++ \
                    git \
+                   git-lfs \
                    glibc-locale \
                    gzip \
                    iproute2 \

--- a/dockerfiles/opensuse/opensuse-15.6/opensuse-15.6-base/Dockerfile
+++ b/dockerfiles/opensuse/opensuse-15.6/opensuse-15.6-base/Dockerfile
@@ -15,6 +15,7 @@ RUN zypper --non-interactive install \
                    gcc \
                    gcc-c++ \
                    git \
+                   git-lfs \
                    glibc-locale \
                    gzip \
                    hostname \

--- a/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-18.04/ubuntu-18.04-base/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         gawk \
         wget \
         git-core \
+        git-lfs \
         subversion \
         diffstat \
         unzip \

--- a/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
         gawk \
         wget \
         git-core \
+        git-lfs \
         subversion \
         diffstat \
         unzip \

--- a/dockerfiles/ubuntu/ubuntu-22.04/ubuntu-22.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-22.04/ubuntu-22.04-base/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         gawk \
         wget \
         git-core \
+        git-lfs \
         subversion \
         diffstat \
         unzip \

--- a/dockerfiles/ubuntu/ubuntu-24.04/ubuntu-24.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-24.04/ubuntu-24.04-base/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         gawk \
         wget \
         git-core \
+        git-lfs \
         subversion \
         diffstat \
         unzip \


### PR DESCRIPTION
Replaces/Closes #40 

The other PR for this stalled out and I've encountered a meta-layer that requires this tool. Since other OS updates have occurred in the meantime, the changes are much simpler this since since all repositories have a version of git-lfs available in them now.

For my immediate need, it's Qt's meta-boot2qt layer that wants this: https://code.qt.io/cgit/yocto/meta-boot2qt.git/tree/meta-boot2qt/conf/layer.conf#n45. Some of their recipes reference repositories that download large binaries (like images and fonts) via git-lfs.