### PR TITLE
Support armv8 Docker images

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-test-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.targetplatform == 'linux/amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     permissions:
       packages: write
     strategy:
@@ -37,7 +37,8 @@ jobs:
           ubuntu-24.04
         ]
         targetplatform: [
-          linux/amd64
+          linux/amd64,
+          linux/arm64/v8
         ]
     env:
       DISTRO_TO_BUILD: ${{ matrix.distro_to_build }}

--- a/dockerfiles/alma/alma-9/alma-9-base/Dockerfile
+++ b/dockerfiles/alma/alma-9/alma-9-base/Dockerfile
@@ -62,11 +62,10 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     groupadd -g 1000 yoctouser && \
     useradd -u 1000 -g yoctouser -m yoctouser
 
-# Install buildtools-make. The original reason this was needed was due to a
-# sanity check for make 4.1.2
-COPY install-buildtools-make.sh /
-RUN bash /install-buildtools-make.sh && \
-    rm /install-buildtools-make.sh
+# Install buildtools-make. This is due to pzstd missing in the zstd aarch64 RPM
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
 
 COPY build-install-dumb-init.sh /
 RUN  bash build-install-dumb-init.sh && \


### PR DESCRIPTION
This pull request adds support for armv8 docker images so that the containers can be natively run on Apple m-series devices, among others.

I did a testrun of the pipeline and it succeeds after a small tweak for alma linux to make sure `pzstd` is available. See https://github.com/boyvanduuren/yocto-dockerfiles/actions/runs/16045225235

The pipeline failed on ubuntu 20, but looking at the last few pipeline runs on master in your project this was already the case.