### PR TITLE
debian-10: change apt sources.list to point to archive repository

### DIFF
--- a/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
+++ b/dockerfiles/debian/debian-10/debian-10-base/Dockerfile
@@ -8,6 +8,8 @@ FROM debian:10
 
 ARG TARGETPLATFORM
 
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+
 RUN apt-get clean && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Debian 10 builds are currently failing.

Debian 10 (buster) is now EOL and updates are moved to the archive apt repo.

https://www.debian.org/distrib/archive

I added a patch to switch updates to the new location.