### PR TITLE
ubuntu-20.04: Fix python-3.9 breakage

### DIFF
--- a/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
+++ b/dockerfiles/ubuntu/ubuntu-20.04/ubuntu-20.04-base/Dockerfile
@@ -61,6 +61,12 @@ RUN apt-get update && \
     echo 'dash dash/sh boolean false' | debconf-set-selections && \
     DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
+# Install buildtools due to python 3.9 requirement
+
+COPY install-buildtools.sh /
+RUN bash /install-buildtools.sh && \
+    rm /install-buildtools.sh
+
 COPY build-install-dumb-init.sh /
 RUN  bash /build-install-dumb-init.sh && \
      rm /build-install-dumb-init.sh && \


### PR DESCRIPTION
The smoke test now requires at least python-3.9, and Ubuntu 20.04 is at python-3.8. Install buildtools which will add a supported python revision.

The same patch was done to ubuntu-18.04 when the smoke test started to require python 3.8.